### PR TITLE
Fix wrong attribute name in "Storing data" guide

### DIFF
--- a/docs/introduction/data-storage.md
+++ b/docs/introduction/data-storage.md
@@ -67,7 +67,7 @@ export class Message extends Storable(Component) {
 
   @expose({get: true, set: true})
   @attribute('string', {validators: [notEmpty(), maxLength(300)]})
-  message = '';
+  text = '';
 
   @expose({get: true}) @attribute('Date') createdAt = new Date();
 }


### PR DESCRIPTION
The documentation refers to a `text` attribute in the `Message` class, but the code example had `message` instead. This is correct in the TS version of the same example.